### PR TITLE
Revised MCHF.ex to fix formatting of input to HF

### DIFF
--- a/examples/CAS_book/MCHF.ex
+++ b/examples/CAS_book/MCHF.ex
@@ -28,7 +28,7 @@ EOF
 
 ../../src/HF <<EOF
 Al,2P,13.
- 1s  2s  2p  3s
+  1s  2s  2p  3s
 3p(1)
 all
 y

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ F90FLAGS += -g -fcheck=all
 
 all: NONH TERMS GENCL HF MCHF PLOTW PRINTW
 
-NONH: NONH.o ANG.o COM.o NJGRAF.o RAD6.o
+NONH: NONH.o ANG.o COM.o NJGRAF.o RAD3.o
 	$(F90) $(F90FLAGS) -o $@ $^
 
 TERMS: TERMS.o
@@ -16,7 +16,7 @@ GENCL: GENCL.o
 HF: HF.o
 	$(F90) $(F90FLAGS) -o $@ $^
 
-MCHF: MCHF.o COM.o RAD6.o
+MCHF: MCHF.o COM.o RAD3.o
 	$(F90) $(F90FLAGS) -o $@ $^
 
 PLOTW: PLOTW.o


### PR DESCRIPTION
This revision fixes an input formatting problem to HF for the closed shells, which affects the way in which electron labels are stored in the output file, wfn.out, written by HF. When the wavefunction file is used in conjunction with the MCHF program (by moving wfn.out to wfn.inp), the precise format requirement for the electron label field causes MCHF to not recognize wavefunctions which exist in the wfn.inp file. This change fixes the problem for the MCHF.ex example script.
